### PR TITLE
Prevent undefined variables with invalid queries

### DIFF
--- a/sources/lib/DatabaseDataCollector.php
+++ b/sources/lib/DatabaseDataCollector.php
@@ -102,7 +102,9 @@ class DatabaseDataCollector extends DataCollector
 
         foreach ($queries as $query) {
             ++$querycount;
-            $time += $query['time_ms'];
+            if (isset($query['time_ms'])) {
+                $time += $query['time_ms'];
+            }
         }
 
         $this->data = compact('queries', 'querycount', 'time');

--- a/views/Profiler/db.html.twig
+++ b/views/Profiler/db.html.twig
@@ -10,9 +10,25 @@
     {% else %}
         <ul class="alt">
             {% for i, query in collector.queries %}
-                <li class="{{ cycle(['odd', 'even'], i) }}" data-extra-info="{{ '%0.2f'|format(query.time_ms) }}" data-target-id="{{ i }}">
+                <li
+                    class="{{ cycle(['odd', 'even'], i) }}"
+                    {% if query.time_ms is defined %}
+                        data-extra-info="{{ '%0.2f'|format(query.time_ms) }}"
+                    {% endif %}
+                    data-target-id="{{ i }}"
+                >
                     <div style="margin-top: 4px" id="queryNo-{{ i }}">
-<small><strong>Connection</strong> {% if query.session_stamp != null %}{{ query.session_stamp }}{% else %} N/A {% endif %} | <strong>Parameters</strong>: {{ query.parameters|yaml_dump }} | <strong>Time</strong>: {{ '%0.2f'|format(query.time_ms) }} ms | <strong>Results</strong>: {{ query.result_count }} | <strong>Entity</strong>: <em>{% if query.flexible_entity is defined %}{{ query.flexible_entity }}{% else %} - {% endif %}</em></small></br />
+                        <small>
+                            <strong>Connection</strong> {% if query.session_stamp != null %}{{ query.session_stamp }}{% else %} N/A {% endif %}
+                            | <strong>Parameters</strong>: {{ query.parameters|yaml_dump }}
+                            {% if query.time_ms is defined %}
+                                | <strong>Time</strong>: {{ '%0.2f'|format(query.time_ms) }} ms
+                            {% endif %}
+                            {% if query.result_count is defined %}
+                                | <strong>Results</strong>: {{ query.result_count }}
+                            {% endif %}
+                            | <strong>Entity</strong>: <em>{% if query.flexible_entity is defined %}{{ query.flexible_entity }}{% else %} - {% endif %}</em>
+                        </small></br />
                         <code id="code-{{ i }}" style="font-size: 14px;">
                             {{ query.sql|sql_format|raw }}
                         </code>


### PR DESCRIPTION
When a query failed, some variables are undefined (``time_ms`` and ``result_count``). This makes errors with silex.

This is a quick fix, highlight these queries seems a good idea.