### PR TITLE
Data array should be properly initialized on reset

### DIFF
--- a/sources/lib/DatabaseDataCollector.php
+++ b/sources/lib/DatabaseDataCollector.php
@@ -41,11 +41,7 @@ class DatabaseDataCollector extends DataCollector
         }
 
         $this->stopwatch = $stopwatch;
-        $this->data = [
-            'time' => 0,
-            'queries' => [],
-            'exception' => null,
-        ];
+        $this->initData();
     }
 
     /**
@@ -150,6 +146,18 @@ class DatabaseDataCollector extends DataCollector
     public function reset()
     {
         $this->stopwatch->reset();
-        $this->data = array();
+        $this->initData();
+    }
+
+    /**
+     * Init data array
+     */
+    private function initData()
+    {
+        $this->data = [
+            'time' => 0,
+            'queries' => [],
+            'exception' => null,
+        ];
     }
 }


### PR DESCRIPTION
In Behat tests I had some nasty notices like "Notice: Undefined index: time in vendor/pomm-project/pomm-symfony-bridge/sources/lib/DatabaseDataCollector.php line 62"

Data reset should set back data array to construct values, not an empty array.