### PR TITLE
Extractors return null with non Pomm classes

### DIFF
--- a/sources/lib/PropertyInfo/Extractor/ListExtractor.php
+++ b/sources/lib/PropertyInfo/Extractor/ListExtractor.php
@@ -47,6 +47,10 @@ class ListExtractor implements PropertyListExtractorInterface
             $model_name = "${class}Model";
         }
 
+        if (!class_exists($model_name)) {
+            return;
+        }
+
         return $this->getPropertiesList($session, $model_name);
     }
 

--- a/sources/lib/PropertyInfo/Extractor/TypeExtractor.php
+++ b/sources/lib/PropertyInfo/Extractor/TypeExtractor.php
@@ -48,6 +48,10 @@ class TypeExtractor implements PropertyTypeExtractorInterface
             $model_name = "${class}Model";
         }
 
+        if (!class_exists($model_name)) {
+            return;
+        }
+
         $sql_type = $this->getSqlType($session, $model_name, $property);
         $pomm_type = $this->getPommType($session, $sql_type);
 


### PR DESCRIPTION
When the extractors are loaded in the Symfony PropertyInfoExtractor, they failed with an exception on non Pomm classes (like with a POPO class). The PropertyInfoExtractor doesn't expect an exception, just a null return value, to try another extractor.

This PR add the null return when the classes doesn't have a Model counterpart.

~This PR also fix a Type problem for Boolean with the Type extractor.~
