### PR TITLE
Fix the Type extractor for boolean

### DIFF
--- a/sources/lib/PropertyInfo/Extractor/TypeExtractor.php
+++ b/sources/lib/PropertyInfo/Extractor/TypeExtractor.php
@@ -99,9 +99,13 @@ class TypeExtractor implements PropertyTypeExtractorInterface
 
         switch ($pomm_type) {
             case 'Array':
-            case 'Boolean':
+                $type = Type::BUILTIN_TYPE_ARRAY;
+                break;
             case 'String':
-                $type = strtolower($pomm_type);
+                $type = Type::BUILTIN_TYPE_STRING;
+                break;
+            case 'Boolean':
+                $type = Type::BUILTIN_TYPE_BOOL;
                 break;
             case 'Number':
                 $type = Type::BUILTIN_TYPE_INT;


### PR DESCRIPTION
The Type extractor doesn't return the right type information for Array, String and Boolean type.

